### PR TITLE
chore: update to target sdk 29

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,13 +32,13 @@ androidExtensions {
 }
 
 dependencies {
-    implementation 'com.android.support:preference-v7:28.0.0'
     implementation 'com.android.volley:volley:1.1.1'
     implementation 'com.google.android.material:material:1.1.0-beta01'
     implementation "android.arch.lifecycle:extensions:1.1.1"
     implementation "androidx.annotation:annotation:1.1.0"
     implementation "androidx.core:core-ktx:1.1.0"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.1.0"
+    implementation 'androidx.preference:preference:1.1.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50"
 
     // MLKit Dependencies

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,11 +3,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         applicationId "com.google.firebase.ml.md"
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/com/google/firebase/ml/md/kotlin/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/google/firebase/ml/md/kotlin/settings/SettingsFragment.kt
@@ -35,7 +35,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
     private fun setUpRearCameraPreviewSizePreference() {
         val previewSizePreference =
-            findPreference(getString(R.string.pref_key_rear_camera_preview_size)) as ListPreference
+                findPreference<ListPreference>(getString(R.string.pref_key_rear_camera_preview_size))!!
 
         var camera: Camera? = null
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:3.5.2'
         classpath 'com.google.gms:google-services:4.3.2' // google-services plugin
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50"
     }


### PR DESCRIPTION
The auto build in #24 is currently failing because we were still using the support library for Android Preferences.
This PR should:
- Migrate to the AndroidX version of Android Preferences
- Update the project to target SDK 29