### PR TITLE
Adding support for devices with long screens

### DIFF
--- a/app/src/main/java/com/google/firebase/ml/md/java/camera/CameraSourcePreview.java
+++ b/app/src/main/java/com/google/firebase/ml/md/java/camera/CameraSourcePreview.java
@@ -101,12 +101,21 @@ public class CameraSourcePreview extends FrameLayout {
       }
     }
 
-    // Match the width of the child view to its parent.
-    int childWidth = layoutWidth;
-    int childHeight = (int) (childWidth / previewSizeRatio);
-    if (childHeight <= layoutHeight) {
+    int childWidth = (int) (layoutHeight * previewSizeRatio);
+    int childHeight = (int) (layoutWidth / previewSizeRatio);
+    if (layoutWidth <= childWidth) {
+      // When the child view is too wide to be fitted in its parent: If the child view is static
+      // overlay view container (contains views such as bottom prompt chip), we apply the size of
+      // the parent view to it. Otherwise, we offset the left/right position equally to position it
+      // in the center of the parent.
+      int excessLenInHalf = (childWidth - layoutWidth) / 2;
       for (int i = 0; i < getChildCount(); ++i) {
-        getChildAt(i).layout(0, 0, childWidth, childHeight);
+        View childView = getChildAt(i);
+        if (childView.getId() == R.id.static_overlay_container) {
+          getChildAt(i).layout(0, 0, layoutWidth, layoutHeight);
+        } else {
+          childView.layout(-excessLenInHalf, 0, layoutWidth + excessLenInHalf, layoutHeight);
+        }
       }
     } else {
       // When the child view is too tall to be fitted in its parent: If the child view is static
@@ -117,9 +126,9 @@ public class CameraSourcePreview extends FrameLayout {
       for (int i = 0; i < getChildCount(); ++i) {
         View childView = getChildAt(i);
         if (childView.getId() == R.id.static_overlay_container) {
-          childView.layout(0, 0, childWidth, layoutHeight);
+          childView.layout(0, 0, layoutWidth, layoutHeight);
         } else {
-          childView.layout(0, -excessLenInHalf, childWidth, layoutHeight + excessLenInHalf);
+          childView.layout(0, -excessLenInHalf, layoutWidth, layoutHeight + excessLenInHalf);
         }
       }
     }

--- a/app/src/main/java/com/google/firebase/ml/md/kotlin/camera/CameraSourcePreview.kt
+++ b/app/src/main/java/com/google/firebase/ml/md/kotlin/camera/CameraSourcePreview.kt
@@ -90,11 +90,25 @@ class CameraSourcePreview(context: Context, attrs: AttributeSet) : FrameLayout(c
             }
         } ?: layoutWidth.toFloat() / layoutHeight.toFloat()
 
-        // Match the width of the child view to its parent.
+        val childWidth = (layoutHeight * previewSizeRatio).toInt()
         val childHeight = (layoutWidth / previewSizeRatio).toInt()
-        if (childHeight <= layoutHeight) {
+        if (layoutWidth <= childWidth) {
+            // When the child view is too wide to be fitted in its parent: If the child view is static
+            // overlay view container (contains views such as bottom prompt chip), we apply the size of
+            // the parent view to it. Otherwise, we offset the left/right position equally to position it
+            // in the center of the parent.
+            val excessLenInHalf = (childWidth - layoutWidth) / 2
             for (i in 0 until childCount) {
-                getChildAt(i).layout(0, 0, layoutWidth, childHeight)
+                val childView = getChildAt(i)
+                when (childView.id) {
+                    R.id.static_overlay_container -> {
+                        childView.layout(0, 0, layoutWidth, layoutHeight)
+                    }
+                    else -> {
+                        childView.layout(
+                                -excessLenInHalf, 0, layoutWidth + excessLenInHalf, layoutHeight)
+                    }
+                }
             }
         } else {
             // When the child view is too tall to be fitted in its parent: If the child view is


### PR DESCRIPTION
This change will fix an issue where the camera preview is only covering a part of the screen on devices with long screens, such as Samsung Galaxy A50.